### PR TITLE
Don't save Linux addresses as full 64-bit (canonical) addresses

### DIFF
--- a/main.go
+++ b/main.go
@@ -399,7 +399,7 @@ func locationToUint64(loc *dwarf.Field, addressSize int) uint64 {
 		}
 	}
 
-	return result
+	return result & 0xffffffffffff
 }
 
 func structName(dwarfStruct *dwarf.StructType) string {
@@ -984,7 +984,7 @@ func processSystemMap(doc *vtypeJson, systemMap io.Reader) error {
 		if !ok {
 			sym = &vtypeSymbol{Address: addr, SymbolType: voidType}
 		} else {
-			sym.Address = addr
+			sym.Address = addr & 0xffffffffffff
 		}
 		doc.Symbols[symName] = sym
 	}
@@ -1021,7 +1021,7 @@ func processElfSymTab(doc *vtypeJson, elfFile *elf.File, extract Extract) error 
 		if !ok {
 			sym = &vtypeSymbol{Address: elfsym.Value, SymbolType: voidType}
 		} else {
-			sym.Address = elfsym.Value
+			sym.Address = elfsym.Value & 0xffffffffffff
 		}
 		doc.Symbols[elfsym.Name] = sym
 	}


### PR DESCRIPTION
Saving addresses in the json as full 64-bit values presents a problem for many json parsers that are unable to process them. The addresses above bit 48 don't contain any useful information and the full canonical address can be simply reconstructed by checking if bit 47 is set or not. Rekall's jsons for Linux were also saved this way.

If you still prefer the default jsons to be stored with the full canonical addresses, I would also be happy if there was a command line option for this.