### PR TITLE
Linux module method

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,11 +41,12 @@ type Extract int
 
 // Defines information to extract during processing steps
 const (
-	DwarfSymbols  Extract = 1
-	DwarfTypes    Extract = 2
-	SymTabSymbols Extract = 4
-	ConstantData  Extract = 8
-	SystemMap     Extract = 16
+	DwarfSymbols         Extract = 1
+	DwarfTypes           Extract = 2
+	SymTabSymbols        Extract = 4
+	ConstantData         Extract = 8
+	SystemMap            Extract = 16
+	ReferenceSymbolTypes Extract = 32
 )
 
 // FileToProcess defines the file that needs to be processed and
@@ -596,6 +597,7 @@ Commands:
 	systemMapPaths := linuxArgs.StringArray("system-map", nil, "System.Map file `PATH` to extract symbol information")
 	elfTypePaths := linuxArgs.StringArray("elf-types", nil, "ELF file `PATH` to extract only type information")
 	elfSymbolPaths := linuxArgs.StringArray("elf-symbols", nil, "ELF file `PATH` to extract only symbol information")
+	symbolTypesReferencePath := linuxArgs.String("reference-symbols", "", "ISF reference file with symbol types")
 	linuxArgs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s linux [OPTIONS]\n\n", TOOL_NAME)
 		linuxArgs.PrintDefaults()
@@ -670,6 +672,11 @@ Commands:
 		// System.Map processing
 		for _, filePath := range *systemMapPaths {
 			filesToProcess.Add(FileToProcess{FilePath: filePath, Extract: SystemMap})
+		}
+
+		// Reference symbol types
+		if *symbolTypesReferencePath != "" {
+			filesToProcess.Add(FileToProcess{FilePath: *symbolTypesReferencePath, Extract: ReferenceSymbolTypes})
 		}
 
 		if len(filesToProcess) == 0 {
@@ -917,9 +924,24 @@ func generateLinux(files FilesToProcess, linuxBanner string) (*vtypeJson, error)
 			if err != nil {
 				return nil, fmt.Errorf("could not open %s: %v", f.FilePath, err)
 			}
+			defer r.Close()
 
 			if err := processSystemMap(doc, r); err != nil {
 				return nil, fmt.Errorf("error processing system map: %v", err)
+			}
+			continue
+		}
+
+		// process reference symbol types, and skip to the next file
+		if extract := f.Extract & (ReferenceSymbolTypes); extract != 0 {
+			r, err := os.Open(f.FilePath)
+			if err != nil {
+				return nil, fmt.Errorf("could not open %s: %v", f.FilePath, err)
+			}
+			defer r.Close()
+
+			if err := processReferenceSymbolTypes(doc, r); err != nil {
+				return nil, fmt.Errorf("error processing reference symbol types: %v", err)
 			}
 			continue
 		}
@@ -965,6 +987,44 @@ func generateLinux(files FilesToProcess, linuxBanner string) (*vtypeJson, error)
 	}
 
 	return doc, nil
+}
+
+// processRefernceSymbolTypes adds symbol types from the reference reader.
+// The reader is assumed to the a valid vtypeJson marshalled file.
+func processReferenceSymbolTypes(doc *vtypeJson, refSymbolTypes io.Reader) error {
+	var refDoc vtypeJson
+	dec := json.NewDecoder(refSymbolTypes)
+	err := dec.Decode(&refDoc)
+	if err != nil {
+		return err
+	}
+
+	//Sort ref symbols in alph order
+	refSymbols := make([]string, 0, len(refDoc.Symbols))
+	for k := range refDoc.Symbols {
+		refSymbols = append(refSymbols, k)
+	}
+	sort.Strings(refSymbols)
+
+	//Create a cache of doc symbols in alph order
+	docSymbols := make([]string, 0, len(doc.Symbols))
+	for k := range doc.Symbols {
+		docSymbols = append(docSymbols, k)
+	}
+	sort.Strings(docSymbols)
+
+	//For each match, replace doc symbol type with reference symbol type
+	refIndex := 0
+	for _, symName := range docSymbols {
+		for j := refIndex; j < len(refSymbols); j++ {
+			if symName == refSymbols[j] {
+				doc.Symbols[symName].SymbolType = refDoc.Symbols[symName].SymbolType
+				refIndex = j
+				break
+			}
+		}
+	}
+	return nil
 }
 
 // processSystemMap adds the missing symbol information from system.map to vtypeJson doc


### PR DESCRIPTION
Add support for generating a symbols file when debug symbols for a Linux kernel are not available.

The types can be obtained from a kernel module that is compiled against the kernel headers (same approach as in volatility2 profiles). Symbol addresses and names come from System.map. This PR provides the following additional features:

* linux banner information can be supplied as a string via a command line flag
* types for symbols defined in System.map can be obtained from a reference symbols file, which is supplied via a command line flag