### PR TITLE
adds the fields in the struct after processing

### DIFF
--- a/main.go
+++ b/main.go
@@ -289,6 +289,8 @@ func (doc *vtypeJson) addDwarf(data *dwarf.Data, endian string, extract Extract)
 				} else {
 					vtypeField.FieldType = fieldType
 				}
+
+				st.Fields[fieldName] = vtypeField
 			}
 
 			name := structName(structType)


### PR DESCRIPTION
Fixes a bug in which fields were being processed but were not being added to structs.