### PR TITLE
I added the calculation needed to change bit_position field from MSB to LSB

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,9 +283,11 @@ func (doc *vtypeJson) addDwarf(data *dwarf.Data, endian string, extract Extract)
 				if field.BitSize != 0 {
 					vtypeField.FieldType = make(map[string]interface{})
 					vtypeField.FieldType["kind"] = "bitfield"
-					vtypeField.FieldType["bit_position"] = field.BitOffset
 					vtypeField.FieldType["bit_length"] = field.BitSize
 					vtypeField.FieldType["type"] = fieldType
+					// calculation to change the DWARF offset from MSB to LSB
+					maxPos := (8 * field.ByteSize) - 1
+					vtypeField.FieldType["bit_position"] = maxPos - (field.BitOffset + (field.BitSize - 1))
 				} else {
 					vtypeField.FieldType = fieldType
 				}


### PR DESCRIPTION
For issue #25:
I first verified that DWARF offsets were calculated from the MSB. This is explained in the DWARF standard: http://dwarfstd.org/doc/Debugging%20using%20DWARF-2012.pdf

Bit offsets for bitfields in Microsoft PDB files are from the Least Significant Bit. Thus, the bit_position field generated by dwaft2json should be converted to match the JSON generated by pdbconv.py which is in volatility3.  

I tested my calculation by comparing my dwarf2json output with pdbconv.py output. 

So, to test I made a test program with different structs with different size bitfields then I generated an elf executable with debugging symbols. I also was able to make exe using MSVC then get a JSON representation of the PDB file using pdbconv.py.

I then compared the JSON objects that were packed the same way and I found that the bit_position field was the same for both the same.
