### PR TITLE
prevent ELF relocations from being applied prior to DWARF parsing

### DIFF
--- a/dwarf.go
+++ b/dwarf.go
@@ -1,0 +1,115 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"compress/zlib"
+	"debug/dwarf"
+	"debug/elf"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// DWARF is a copy of Go's debug/elf func (f *File) DWARF().
+// it has been forked here to prevent relocations from being applied
+// prior to DWARF .debug_info parsing.
+//
+// See #15 for more details.
+func DWARF(f *elf.File) (*dwarf.Data, error) {
+	dwarfSuffix := func(s *elf.Section) string {
+		switch {
+		case strings.HasPrefix(s.Name, ".debug_"):
+			return s.Name[7:]
+		case strings.HasPrefix(s.Name, ".zdebug_"):
+			return s.Name[8:]
+		default:
+			return ""
+		}
+
+	}
+	// sectionData gets the data for s, checks its size, and
+	// applies any applicable relations.
+	sectionData := func(i int, s *elf.Section) ([]byte, error) {
+		b, err := s.Data()
+		if err != nil && uint64(len(b)) < s.Size {
+			return nil, err
+		}
+
+		if len(b) >= 12 && string(b[:4]) == "ZLIB" {
+			dlen := binary.BigEndian.Uint64(b[4:12])
+			dbuf := make([]byte, dlen)
+			r, err := zlib.NewReader(bytes.NewBuffer(b[12:]))
+			if err != nil {
+				return nil, err
+			}
+			if _, err := io.ReadFull(r, dbuf); err != nil {
+				return nil, err
+			}
+			if err := r.Close(); err != nil {
+				return nil, err
+			}
+			b = dbuf
+		}
+
+		// NOTE: removed relocations from original code here
+
+		return b, nil
+	}
+
+	// There are many DWARf sections, but these are the ones
+	// the debug/dwarf package started with.
+	var dat = map[string][]byte{"abbrev": nil, "info": nil, "str": nil, "line": nil, "ranges": nil}
+	for i, s := range f.Sections {
+		suffix := dwarfSuffix(s)
+		if suffix == "" {
+			continue
+		}
+		if _, ok := dat[suffix]; !ok {
+			continue
+		}
+		b, err := sectionData(i, s)
+		if err != nil {
+			return nil, err
+		}
+		dat[suffix] = b
+	}
+
+	d, err := dwarf.New(dat["abbrev"], nil, nil, dat["info"], dat["line"], nil, dat["ranges"], dat["str"])
+	if err != nil {
+		return nil, err
+	}
+
+	// Look for DWARF4 .debug_types sections and DWARF5 sections.
+	for i, s := range f.Sections {
+		suffix := dwarfSuffix(s)
+		if suffix == "" {
+			continue
+		}
+		if _, ok := dat[suffix]; ok {
+			// Already handled.
+			continue
+		}
+
+		b, err := sectionData(i, s)
+		if err != nil {
+			return nil, err
+		}
+
+		if suffix == "types" {
+			if err := d.AddTypes(fmt.Sprintf("types-%d", i), b); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := d.AddSection(".debug_"+suffix, b); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return d, nil
+}

--- a/main.go
+++ b/main.go
@@ -984,7 +984,7 @@ func generateLinux(files FilesToProcess) (*vtypeJson, error) {
 				endian = "big"
 			}
 
-			data, err := elfFile.DWARF()
+			data, err := DWARF(elfFile)
 			if err != nil {
 				return nil, fmt.Errorf("could not get DWARF from %s: %v", f.FilePath, err)
 			}


### PR DESCRIPTION
Prior to this commit, Go's built-in elf.File.DWARF() function was
used to extract DWARF data from an ELF file. This code applies ELF
relocations prior to parsing.

Several Linux kernels were encountered that causes panics due to
stack depth. The root cause was determined to be invalid DWARF
offsets due to ELF relocations.

This commit forks the DWARF() function into its own file and removes
the relocation processing. The code is otherwise unchanged.

main.go has been updated to call the local function instead of the
library.

Addresses issue #15.