### PR TITLE
add go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
Go 1.16 requires entries for 3rd party packages to be present in go.sum.
Missing entries in go.sum result in errors of the form:

go: github.com/spf13/pflag@v1.0.5: missing go.sum entry; to add it:
        go mod download github.com/spf13/pflag

This addresses #32.