### PR TITLE
dwarf2json: add FreeBSD kernel support

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func (f *FilesToProcess) Add(newFile FileToProcess) {
 
 // The symbol names are part of Linux's or Mac's read-only data
 // Their contents will be saved, if the symbol is found
-var constantLinuxDataSymbols = []string{"linux_banner"}
+var constantLinuxDataSymbols = []string{"linux_banner", "version"}
 var constantMacosDataSymbols = []string{"version"}
 
 // The compiler can add a leading underscore to symbol names in the symbol
@@ -615,7 +615,7 @@ func readELFSymbol(file *elf.File, symbol elf.Symbol) ([]byte, error) {
 	var err error
 
 	for _, section := range file.Sections {
-		if section.Name == ".rodata" &&
+		if (section.Name == ".data" || section.Name == ".rodata") &&
 			(section.Flags&elf.SHF_ALLOC) == elf.SHF_ALLOC &&
 			section.Addr <= symbol.Value &&
 			(section.Addr+section.Size) >= (symbol.Value+symbol.Size) {


### PR DESCRIPTION
FreeBSD kernel ISF can be generated the same way as Linux
FreeBSD kernel has a "version" string in the ".data" section

This is how I generate a FreeBSD ISF:
dwarf2json linux --elf /usr/lib/debug/boot/kernel/kernel.debug --elf-symbols /boot/kernel/kernel > FreeBSD-14.0-RELEASE-p5-GENERIC-amd64.json

